### PR TITLE
✨ [Story Preview] Handle page advancement logic when transitioning from the `preview` state to `visible`

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -305,7 +305,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.initializeMediaPool_();
     this.maybeCreateAnimationManager_();
     // DESCRIPTION
-    this.setUpAdvancementConfig_();
+    this.setUpAdvancementConfig_(true /* isFirstSetup */);
     this.getAmpDoc().onVisibilityChanged(() => this.setUpAdvancementConfig_());
     this.setDescendantCssTextStyles_();
     this.storeService_.subscribe(
@@ -323,17 +323,21 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * DESCRIPTION
+   * @param {boolean} isFirstSetup Whether this is the first time that this
+   *     method is being called.
    * @private
    */
-  setUpAdvancementConfig_() {
-    if (!this.getAmpDoc().isPreview() && !this.getAmpDoc().isVisible()) {
+  setUpAdvancementConfig_(isFirstSetup = false) {
+    const ampdoc = this.getAmpDoc();
+    if (!ampdoc.isPreview() && !ampdoc.isVisible() && !isFirstSetup) {
       return;
     }
-    if (this.getAmpDoc().isPreview()) {
+
+    if (ampdoc.isPreview()) {
       // DESCRIPTION
       this.setupAutoAdvanceForPreview_();
     }
-    if (this.getAmpDoc().isVisible()) {
+    if (ampdoc.isVisible()) {
       // DESCRIPTION
       this.setupAutoAdvanceForVisible_();
       this.maybeSetStoryNextUp_();

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -250,6 +250,10 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     /** @private {?number} Time at which an audio element failed playing. */
     this.playAudioElementFromTimestamp_ = null;
+
+    /** @private {?string} DESCRIPTION */
+    this.initialAutoAdvanceValue_ =
+      this.element.getAttribute('auto-advance-after');
   }
 
   /**
@@ -300,18 +304,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();
     this.maybeCreateAnimationManager_();
-    if (this.getAmpDoc().isPreview()) {
-      this.setupAutoAdvanceForPreview_();
-    }
-    this.maybeSetStoryNextUp_();
-    this.advancement_ = AdvancementConfig.forElement(this.win, this.element);
-    this.advancement_.addPreviousListener(() => this.previous());
-    this.advancement_.addAdvanceListener(() =>
-      this.next(/* opt_isAutomaticAdvance */ true)
-    );
-    this.advancement_.addProgressListener((progress) =>
-      this.emitProgress_(progress)
-    );
+    // DESCRIPTION
+    this.setUpAdvancementConfig_();
+    this.getAmpDoc().onVisibilityChanged(() => this.setUpAdvancementConfig_());
     this.setDescendantCssTextStyles_();
     this.storeService_.subscribe(
       StateProperty.UI_STATE,
@@ -324,6 +319,36 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.initializeTabbableElements_();
     this.maybeApplyFirstAnimationFrameOrFinish();
     this.maybeConvertCtaLayerToPageOutlink_();
+  }
+
+  /**
+   * DESCRIPTION
+   * @private
+   */
+  setUpAdvancementConfig_() {
+    if (!this.getAmpDoc().isPreview() && !this.getAmpDoc().isVisible()) {
+      return;
+    }
+    if (this.getAmpDoc().isPreview()) {
+      // DESCRIPTION
+      this.setupAutoAdvanceForPreview_();
+    }
+    if (this.getAmpDoc().isVisible()) {
+      // DESCRIPTION
+      this.setupAutoAdvanceForVisible_();
+      this.maybeSetStoryNextUp_();
+    }
+
+    // DESCRIPTION
+    this.advancement_?.removeAllAddedListeners();
+    this.advancement_ = AdvancementConfig.forElement(this.win, this.element);
+    this.advancement_.addPreviousListener(() => this.previous());
+    this.advancement_.addAdvanceListener(() =>
+      this.next(/* opt_isAutomaticAdvance */ true)
+    );
+    this.advancement_.addProgressListener((progress) =>
+      this.emitProgress_(progress)
+    );
   }
 
   /**
@@ -352,6 +377,22 @@ export class AmpStoryPage extends AMP.BaseElement {
             });
           }
         });
+    }
+  }
+
+  /**
+   * Configures the page to auto advance using default durations.
+   * @private
+   */
+  setupAutoAdvanceForVisible_() {
+    // DESCRIPTION
+    if (this.initialAutoAdvanceValue_) {
+      this.element.setAttribute(
+        'auto-advance-after',
+        this.initialAutoAdvanceValue_
+      );
+    } else {
+      this.element.removeAttribute('auto-advance-after');
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -353,6 +353,15 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.advancement_.addProgressListener((progress) =>
       this.emitProgress_(progress)
     );
+
+    // DESCRIPTION
+    if (
+      this.state_ === PageState.NOT_ACTIVE &&
+      this.isActive() &&
+      !this.advancement_.isRunning()
+    ) {
+      this.advancement_.start();
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -356,7 +356,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     // DESCRIPTION
     if (
-      this.state_ === PageState.NOT_ACTIVE &&
+      this.state_ === PageState.PLAYING &&
       this.isActive() &&
       !this.advancement_.isRunning()
     ) {

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -98,6 +98,13 @@ export class AdvancementConfig {
   }
 
   /**
+   * @return {string} A string indicating the type of advancement config.
+   */
+  getType() {
+    return 'AdvancementConfig';
+  }
+
+  /**
    * @param {function(number)} progressListener A function that handles when the
    *     progress of the current page has been updated.  It accepts a number
    *     between 0.0 and 1.0 as its only argument, that represents the current
@@ -309,6 +316,11 @@ export class ManualAdvancement extends AdvancementConfig {
           : TapNavigationDirection.NEXT,
       },
     };
+  }
+
+  /** @override */
+  getType() {
+    return 'ManualAdvancement';
   }
 
   /** @override */
@@ -806,6 +818,11 @@ export class TimeBasedAdvancement extends AdvancementConfig {
     }
   }
 
+  /** @override */
+  getType() {
+    return 'TimeBasedAdvancement';
+  }
+
   /**
    * @return {number} The current timestamp, in milliseconds.
    * @private
@@ -910,8 +927,6 @@ export class TimeBasedAdvancement extends AdvancementConfig {
    *     that should be displayed.
    */
   setProgressMs(progressMs) {
-    // this.remainingDelayMs_ = this.startTimeMs_ + this.delayMs_ - this.getCurrentTimestampMs_();
-    // The user can submit the progress, which might allow us to use the following calculation, based on setProgressMs() above
     this.remainingDelayMs_ = this.delayMs_ - progressMs;
   }
 
@@ -982,6 +997,11 @@ export class MediaBasedAdvancement extends AdvancementConfig {
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(win);
+  }
+
+  /** @override */
+  getType() {
+    return 'MediaBasedAdvancement';
   }
 
   /**

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -132,6 +132,16 @@ export class AdvancementConfig {
   }
 
   /**
+   * DESCRIPTION
+   */
+  removeAllAddedListeners() {
+    this.progressListeners_ = [];
+    this.advanceListeners_ = [];
+    this.previousListeners_ = [];
+    this.tapNavigationListeners_ = [];
+  }
+
+  /**
    * Invoked when the advancement configuration should begin taking effect.
    */
   start() {

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -867,9 +867,7 @@ export class TimeBasedAdvancement extends AdvancementConfig {
       return 0;
     }
 
-    const progress =
-      (this.getCurrentTimestampMs_() - this.startTimeMs_) / this.delayMs_;
-
+    const progress = this.getProgressMs() / this.delayMs_;
     return Math.min(Math.max(progress, 0), 1);
   }
 
@@ -895,6 +893,26 @@ export class TimeBasedAdvancement extends AdvancementConfig {
       this.remainingDelayMs_ += newDelayMs - this.delayMs_;
     }
     this.delayMs_ = newDelayMs;
+  }
+
+  /**
+   * @return {number} The progress, in terms of milliseconds elapsed.
+   */
+  getProgressMs() {
+    if (this.startTimeMs_ === null) {
+      return 0;
+    }
+    return this.getCurrentTimestampMs_() - this.startTimeMs_;
+  }
+
+  /**
+   * @param {number} progressMs The progress, in terms of milliseconds elapsed,
+   *     that should be displayed.
+   */
+  setProgressMs(progressMs) {
+    // this.remainingDelayMs_ = this.startTimeMs_ + this.delayMs_ - this.getCurrentTimestampMs_();
+    // The user can submit the progress, which might allow us to use the following calculation, based on setProgressMs() above
+    this.remainingDelayMs_ = this.delayMs_ - progressMs;
   }
 
   /**


### PR DESCRIPTION

This PR causes the story page to do the following:
1. Re-initialize `this.advancement_` when moving from the preview state to visible. The advancement in preview mode is a time-based one whereas it should not necessarily be time-based in visible mode

2. The new `setupAutoAdvanceForVisible_()` function is used to help restore the page's advancement to its default, non-preview behavior expected

3. The new `handlePreviewToVisibleTransition_()` function is designed to ensure that the progress bar accurately reflects the page's progress in `visible` mode, specifically after transitioning out of `preview` mode. 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
6. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
7. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
